### PR TITLE
Rename a getAsset function in scheduler.js

### DIFF
--- a/functions/scheduler.js
+++ b/functions/scheduler.js
@@ -21,7 +21,7 @@ const PARTIAL_DAYS = "partialDays";
  */
 exports.handler = function (context, event, callback) {
   let response = createResponseObject(); //create Twilio Response
-  const schedule = getAsset("schedule.js"); //get the schdule from assets
+  const schedule = getPrivateAsset("schedule.js"); //get the schedule from assets
 
   // set some variables
   const currentDate = moment().tz(TIMEZONE).format("MM/DD/YYYY");
@@ -137,7 +137,7 @@ const createResponseObject = () => {
  * @param {Array} data - The array of cell header names
  * @return {Object} - Returns the fetched asset as an Object
  */
-const getAsset = (assetName) => {
+const getPrivateAsset = (assetName) => {
   const assets = Runtime.getAssets();
   const privateAsset = assets[`/${assetName}`];
   const privatePath = privateAsset.path;


### PR DESCRIPTION
1. Renamed getAsset to getPrivateAsset to be more clear
   * https://github.com/MutualAidNYC/mutual-aid-call-center/blob/e882bbfbfd6e4b326518ac5389d9c4d583f68ccf/functions/scheduler.js#L24
    * https://github.com/MutualAidNYC/mutual-aid-call-center/blob/e882bbfbfd6e4b326518ac5389d9c4d583f68ccf/functions/scheduler.js#L140
2. Fixed a typo in a comment on line 24 
   * https://github.com/MutualAidNYC/mutual-aid-call-center/blob/e882bbfbfd6e4b326518ac5389d9c4d583f68ccf/functions/scheduler.js#L24

This closes #6