### PR TITLE
docs chore: Update README, create CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue, slack (_#digital-tech_), or any other method with the members of the Mutual Aid NYC digital-tech group before making a change.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
+2. Update the README.md with high details of changes if applicable.
+3. Create a Pull Request between your forked repository's branch to MutualAidNYC/mutual-aid-call-center master branch
+4. You may merge the PR once you have the sign-off from another developers, or if you do not have permission to do that, you can ask the reviewer to merge it for you.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ While twilio allows for functions to be written using their UI only website to c
 
 ## Getting Started
 
-1. Copy `.env-sample` to `.env` with the command: `$ cp .env-sample .env`
-
-Copy the necessary values (surrounded by double quotes) into `.env`, including:
-
-Once the `.env` values are in place, install the npm packages
-
 1. Have nodeJS installed locally
 2. Have [NVM](https://github.com/nvm-sh/nvm#installation-and-update "Node Version Manager") installed locally and use node version of 10.17.0 while developing. Verify using the comand `node -v`
 3. Have NPM installed, verify with the command `npm -v`
@@ -23,20 +17,19 @@ Once the `.env` values are in place, install the npm packages
 7. Request from an admin, API key and the secret
 8. Create `.env` in the root of the project file
 
-   1. Copy `.env-sample` to `.env` with the command: `$ cp .env-sample .env`:
-
-9. Change the values in `.env` file, by creating a [Twilio API Key](https://www.twilio.com/console/project/api-keys/) or having an administrator provide it to you. This will NOT be uploaded for security to github as it is git ignored.
-   - `ACCOUNT_SID`: Your own personal API SID key
-   - `AUTH_TOKEN`: Your own personal secret
+   1. Copy `.env-sample` to `.env` with the command: `$ cp .env-sample .env`
+   2. Change the values in `.env` file, by getting the [Twilio API sid and auth_token](https://www.twilio.com/console/project/settings) or having an administrator provide it to you. This will NOT be uploaded for security to github as it is git ignored.
+      - `ACCOUNT_SID`: The Account SID
+      - `AUTH_TOKEN`: Auth Token
 
 ## Instructions for local development
 
-- Not fully tested
+- Can only be used for functions that service webhooks, not for functions used in Twilio Studio
 
 1. Start a locally running server with the command '\$ npm start`
    1. Do note any warnings like wrong version of NodeJS and resolve as needed.
 2. Use a tool to expose your computer's local server using something like [ngrok](https://ngrok.com/)
-3. Point twilio services i.e TaskRouter or Studio Reidrect Widgets to use the locally running server instead of the serverless functions or hosted private/public assets
+3. Point twilio services i.e Phone numbers, TaskRouter or Studio Reidrect Widgets to use the locally running server instead of the serverless functions or hosted private/public assets
 
 - This will only work if you provide Twiml responses such as [TwiML™ for Programmable Voice](https://www.twilio.com/docs/voice/twiml)
 - JSON responses such as `Twilio.Response()` don't appear to work for passing variables back into Studio flows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mutual-aid-call-center",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "twilio-run --env",
     "deploy": "twilio-run deploy",
     "deploy-force": "twilio-run deploy --override-existing-project",
-    "deploy-prod": "twilio-run deploy --environment=production"
+    "deploy-prod": "twilio-run deploy --environment=production --override-existing-project"
   },
   "devDependencies": {
     "twilio-run": "2.* || >2.0.0-rc"


### PR DESCRIPTION
1. Added clarifications to the README
   1. Changed the getting started instructions to be more accurate,
      with the proper sid and auth_token
   2. Indicate that the local dev environment is only for webhooks
2. Update package.json npm script for `deploy` to allow deployments
   without a .twilio-functions file
4. While testing, package-lock was updated to our latest version number
5. Add a CONTRIBUTING file to provide instructions for contributions