### PR TITLE
Feat: update syncWorker to store worker sid

### DIFF
--- a/src/service/airtableController.js
+++ b/src/service/airtableController.js
@@ -95,6 +95,20 @@ class AirtableController {
     return result;
   }
 
+  async updateRecords(baseId, table, records = []) {
+    const base = this.airtable.base(baseId);
+    const baseTable = base(table);
+    let recordsToUpdate = records.slice(0);
+    while (recordsToUpdate.length) {
+      const batch = recordsToUpdate.slice(0, 10);
+      recordsToUpdate = recordsToUpdate.slice(10);
+      /* eslint-disable no-await-in-loop */
+      await baseTable.update(batch);
+      await sleep(250);
+      /* eslint-enable no-await-in-loop */
+    }
+  }
+
   set taskRouter(tr) {
     this.tr = tr;
   }

--- a/src/service/airtableController.js
+++ b/src/service/airtableController.js
@@ -95,7 +95,7 @@ class AirtableController {
     return result;
   }
 
-  async updateRecords(baseId, table, records = []) {
+  async updateRecords(baseId, table, records) {
     const base = this.airtable.base(baseId);
     const baseTable = base(table);
     let recordsToUpdate = records.slice(0);

--- a/src/service/airtableController.js
+++ b/src/service/airtableController.js
@@ -122,8 +122,10 @@ class AirtableController {
     return pageProcessor.bind(this);
   }
 
-  async fetchAllRecordsFromTable(table, base) {
-    const urlifiedTableName = table.replace(' ', '%20');
+  async fetchAllRecordsFromTable(table, base, view = 'Grid view') {
+    const urlify = (phrase) => phrase.replace(' ', '%20');
+    const urlifiedTableName = urlify(table);
+    const urlifiedView = urlify(view);
     let count = 0;
     const maxTries = 2000;
     // eslint-disable-next-line no-constant-condition
@@ -138,7 +140,7 @@ class AirtableController {
               Authorization: `Bearer ${config.airtable.apiKey}`,
             },
             method: 'get',
-            url: `https://api.airtable.com/v0/${base}/${urlifiedTableName}?view=Grid%20view`,
+            url: `https://api.airtable.com/v0/${base}/${urlifiedTableName}?view=${urlifiedView}`,
             data: {
               view: 'Grid%20view',
             },

--- a/test/service/airtableController.test.js
+++ b/test/service/airtableController.test.js
@@ -427,4 +427,42 @@ describe('airtableController', () => {
       expect(stub.firstCall.args[4]).to.equal(recordingId);
     });
   });
+  describe('updateRecords', () => {
+    const tableName = 'some table';
+    let updateStub;
+    let baseStub;
+    let selectedBaseStub;
+    const records = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    beforeEach(() => {
+      baseStub = sinon.stub(airtableController.airtable, 'base');
+      updateStub = sinon.stub();
+      // updateStub.callsArgWith(2, undefined, record);
+      selectedBaseStub = sinon.stub();
+
+      baseStub.returns(selectedBaseStub);
+      selectedBaseStub.returns({ update: updateStub });
+    });
+    afterEach(() => {
+      baseStub.restore();
+    });
+    it('Updates the specified record', async () => {
+      await airtableController.updateRecords(baseId, tableName, records);
+      expect(baseStub.firstCall.firstArg).to.equal(baseId);
+      expect(selectedBaseStub.firstCall.firstArg).to.equal(tableName);
+      expect(updateStub.calledTwice).to.equal(true);
+      expect(updateStub.firstCall.firstArg).to.eql([
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+      ]);
+      expect(updateStub.secondCall.firstArg).to.eql([10, 11, 12, 13, 14, 15]);
+    });
+  });
 });

--- a/test/service/airtableController.test.js
+++ b/test/service/airtableController.test.js
@@ -292,9 +292,10 @@ describe('airtableController', () => {
     ];
     let axiosStub;
     let clock;
+    const view = 'a view';
     const axiosConfig1 = {
       method: 'get',
-      url: `https://api.airtable.com/v0/${config.airtable.phoneBase}/General%20Hours?view=Grid%20view`,
+      url: `https://api.airtable.com/v0/${config.airtable.phoneBase}/General%20Hours?view=a%20view`,
       headers: {
         Authorization: `Bearer ${config.airtable.apiKey}`,
       },
@@ -304,7 +305,7 @@ describe('airtableController', () => {
     };
     const axiosConfig2 = {
       method: 'get',
-      url: `https://api.airtable.com/v0/${config.airtable.phoneBase}/General%20Hours?view=Grid%20view`,
+      url: `https://api.airtable.com/v0/${config.airtable.phoneBase}/General%20Hours?view=a%20view`,
       headers: {
         Authorization: `Bearer ${config.airtable.apiKey}`,
       },
@@ -328,6 +329,7 @@ describe('airtableController', () => {
         await airtableController.fetchAllRecordsFromTable(
           table,
           config.airtable.phoneBase,
+          view,
         ),
       ).to.eql(fullList);
       expect(axiosStub.firstCall.firstArg).to.eql(axiosConfig1);
@@ -342,6 +344,7 @@ describe('airtableController', () => {
       airtableController.fetchAllRecordsFromTable(
         table,
         config.airtable.phoneBase,
+        view,
       );
       clock.tick(200);
       await clock.tickAsync(49);
@@ -353,6 +356,7 @@ describe('airtableController', () => {
       airtableController.fetchAllRecordsFromTable(
         table,
         config.airtable.phoneBase,
+        view,
       );
       clock.tick(29500);
       await clock.tickAsync(499);


### PR DESCRIPTION
1. Updated fetchAllRecordsFromTable to allow for any view
2. Create updateRecords for airtable class to allow up to 10 records to be updated simultaneously 
3. syncWorker no longer looks for a Language field
4. syncWorker now defaults to all workers knowing just english
(shift start will set correct languages)
5. syncWorker will now store new worker sid in airtable
6. All tests have been written or modified

This PR will resolve #37