### PR TITLE
feat: Rename Volunteer Availability Log

### DIFF
--- a/src/service/twilioTaskRouter.js
+++ b/src/service/twilioTaskRouter.js
@@ -179,7 +179,7 @@ class TwilioTaskRouter {
     });
     await airtableController.createRecords(
       config.airtable.phoneBase,
-      'Volunteer Availability Log',
+      'Sign In / Sign Out record',
       logRecords,
     );
   }
@@ -369,7 +369,7 @@ class TwilioTaskRouter {
         try {
           await airtableController.addRowToTable(
             config.airtable.phoneBase,
-            'Volunteer Availability Log',
+            'Sign In / Sign Out record',
             rowObj,
           );
         } catch (e) {
@@ -384,7 +384,7 @@ class TwilioTaskRouter {
         rowObj.Availability = 'Available';
         airtableController.addRowToTable(
           config.airtable.phoneBase,
-          'Volunteer Availability Log',
+          'Sign In / Sign Out record',
           rowObj,
         );
       } else {
@@ -579,7 +579,7 @@ class TwilioTaskRouter {
     logger.info('StartShift logRecords: %O', logRecords);
     await airtableController.createRecords(
       config.airtable.phoneBase,
-      'Volunteer Availability Log',
+      'Sign In / Sign Out record',
       logRecords,
     );
   }

--- a/test/service/twilioTaskRouter.test.js
+++ b/test/service/twilioTaskRouter.test.js
@@ -143,7 +143,7 @@ describe('TwilioTaskRouter class', () => {
       });
       expect(addRowStub.firstCall.args[0]).to.equal(config.airtable.phoneBase);
       expect(addRowStub.firstCall.args[1]).to.equal(
-        'Volunteer Availability Log',
+        'Sign In / Sign Out record',
       );
       expect(addRowStub.firstCall.args[2]).to.eql({
         'Unique Name': 'Bob Marley',
@@ -172,7 +172,7 @@ describe('TwilioTaskRouter class', () => {
 
       expect(addRowStub.firstCall.args[0]).to.equal(config.airtable.phoneBase);
       expect(addRowStub.firstCall.args[1]).to.equal(
-        'Volunteer Availability Log',
+        'Sign In / Sign Out record',
       );
       expect(addRowStub.firstCall.args[2]).to.eql({
         'Unique Name': 'Jane Doe',
@@ -1610,7 +1610,7 @@ describe('TwilioTaskRouter class', () => {
         config.airtable.phoneBase,
       );
       expect(createRecordsStub.firstCall.args[1]).to.equal(
-        'Volunteer Availability Log',
+        'Sign In / Sign Out record',
       );
       expect(createRecordsStub.firstCall.args[2]).to.eql([
         {
@@ -1763,7 +1763,7 @@ describe('TwilioTaskRouter class', () => {
         config.airtable.phoneBase,
       );
       expect(createRecordsStub.firstCall.args[1]).to.equal(
-        'Volunteer Availability Log',
+        'Sign In / Sign Out record',
       );
       expect(createRecordsStub.firstCall.args[2]).to.eql([
         {


### PR DESCRIPTION
It was requested to be changed to 'Sign In / Sign Out record'

This commit resolves #60