### PR TITLE
Triple the agent-gather input timeout

### DIFF
--- a/src/service/twilioTaskRouter.js
+++ b/src/service/twilioTaskRouter.js
@@ -239,6 +239,7 @@ class TwilioTaskRouter {
       method: 'POST',
       numDigits: 1,
       actionOnEmptyResult: true,
+      timeout: 15,
     });
     gather.play(
       `https://${

--- a/test/service/twilioTaskRouter.test.js
+++ b/test/service/twilioTaskRouter.test.js
@@ -607,7 +607,7 @@ describe('TwilioTaskRouter class', () => {
         fetchTaskStub.resolves(task);
 
         expect(await taskRouter.handleAgentConnected(event)).to.equal(
-          `<?xml version="1.0" encoding="UTF-8"?><Response><Gather action="https://${config.hostName}/api/agent-gather" method="POST" numDigits="1" actionOnEmptyResult="true"><Play>https://${config.hostName}/assets/receiving_call_in_german.mp3</Play></Gather></Response>`,
+          `<?xml version="1.0" encoding="UTF-8"?><Response><Gather action="https://${config.hostName}/api/agent-gather" method="POST" numDigits="1" actionOnEmptyResult="true" timeout="15"><Play>https://${config.hostName}/assets/receiving_call_in_german.mp3</Play></Gather></Response>`,
         );
         expect(
           getWorkersReservationsStub.calledOnceWith('WKbaloney2', {
@@ -640,7 +640,7 @@ describe('TwilioTaskRouter class', () => {
         fetchTaskStub.resolves(task);
 
         expect(await taskRouter.handleAgentConnected(event)).to.equal(
-          `<?xml version="1.0" encoding="UTF-8"?><Response><Gather action="https://${config.hostName}/api/agent-gather" method="POST" numDigits="1" actionOnEmptyResult="true"><Play>https://${config.hostName}/assets/receiving_call_in_german.mp3</Play></Gather></Response>`,
+          `<?xml version="1.0" encoding="UTF-8"?><Response><Gather action="https://${config.hostName}/api/agent-gather" method="POST" numDigits="1" actionOnEmptyResult="true" timeout="15"><Play>https://${config.hostName}/assets/receiving_call_in_german.mp3</Play></Gather></Response>`,
         );
         expect(
           getWorkersReservationsStub.calledOnceWith('WKbaloney2', {


### PR DESCRIPTION
Folks have reported having issues responding to the prompt quickly enough, so let's up the timeout from the default of 5s to 15s.